### PR TITLE
Setting version of Kwave in the Cmake files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,11 +22,6 @@
 #                                                                           #
 #############################################################################
 
-#############################################################################
-### project name and version                                              ###
-
-PROJECT(kwave)
-
 # KDE Application Version, managed by release script
 set (RELEASE_SERVICE_VERSION_MAJOR "20")
 set (RELEASE_SERVICE_VERSION_MINOR "11")
@@ -105,6 +100,11 @@ SET(KWAVE_VERSION_MINOR ${RELEASE_SERVICE_VERSION_MINOR})
 SET(KWAVE_VERSION_MICRO ${RELEASE_SERVICE_VERSION_MICRO})
 SET(KWAVE_VERSION "${KWAVE_VERSION_MAJOR}.${KWAVE_VERSION_MINOR}.${KWAVE_VERSION_MICRO}")
 MESSAGE(STATUS "Building Kwave version ${KWAVE_VERSION}")
+
+#############################################################################
+### project name and version                                              ###
+
+PROJECT(Kwave VERSION ${KWAVE_VERSION})
 
 #############################################################################
 ### show the compiler name and version                                    ###


### PR DESCRIPTION
This would help give the app stream metadata. As these applications like Discover use this version as metadata for a listing of the application.

This is a fix proposed for the following bug pointed to on Bugzilla: https://bugs.kde.org/show_bug.cgi?id=425034

A similar change was also proposed to Kdenline for similar reasons, which can be seen here: https://github.com/KDE/kdenlive/commit/50085b9fca6690e22145a0afbf3882746877bf68